### PR TITLE
Allow aborting admin commands

### DIFF
--- a/hw/nvme_adm.c
+++ b/hw/nvme_adm.c
@@ -706,7 +706,7 @@ static uint32_t adm_cmd_abort(NVMEState *n, NVMECmd *cmd, NVMECQE *cqe)
         sf->sc = NVME_SC_INVALID_NAMESPACE;
         return FAIL;
     }
-    if (c->sqid == 0 || adm_check_sqid(n, c->sqid)) {
+    if (adm_check_sqid(n, c->sqid)) {
         LOG_NORM("Invalid queue:%d to abort", c->sqid);
         sf->sct = NVME_SCT_CMD_SPEC_ERR;
         sf->sc = NVME_REQ_CMD_TO_ABORT_NOT_FOUND;


### PR DESCRIPTION
The NVME specification allows aborting commands submitted to either IO
or admin queues. Therefore, remove the check for queue ID 0 (admin
submission queue) being an invalid queue.
