### PR TITLE
NVMe: add variative page size support

### DIFF
--- a/hw/nvme.c
+++ b/hw/nvme.c
@@ -334,6 +334,8 @@ static void nvme_mmio_writel(void *opaque, target_phys_addr_t addr,
                  */
                 if (nvme_dev->cq[ACQ_ID].dma_addr &&
                     nvme_dev->sq[ASQ_ID].dma_addr) {
+                    /* set host page size based on value passed by host */
+                     nvme_dev->host_page_size = 1 << (12 + ((val >> 7) & 0xf));
                     /* Update CSTS.RDY based on CC.EN and set the phase tag */
                     nvme_dev->cntrl_reg[NVME_CTST] |= CC_EN ;
                     nvme_dev->cq[ACQ_ID].phase_tag = 1;

--- a/hw/nvme.h
+++ b/hw/nvme.h
@@ -489,6 +489,7 @@ typedef struct NVMEState {
     int bar0_size;
     uint8_t nvectors;
 
+    unsigned int host_page_size; /* it is possible to set different page sizes through CC reg */
     /* Space for NVME Ctrl Space except doorbells */
     uint8_t *cntrl_reg;
     /* Masks for NVME Ctrl Registers */


### PR DESCRIPTION
There is a possibility to set different page sizes through CC.MPS, but qemu NVMe implementation uses only PAGE_SIZE. This might be useful, for example, when guest and qemu have different PAGE_SIZE values
